### PR TITLE
Fix/typescript example remove log component

### DIFF
--- a/typescript/app/logs.riot
+++ b/typescript/app/logs.riot
@@ -1,0 +1,13 @@
+<logs>
+
+  <h4>Logs</h4>
+
+  <button onclick={props.onclear}>
+    Clear logs
+  </button>
+
+  <ul>
+    <li each={ log in props.logs }>{ log.text }</li>
+  </ul>
+
+</logs>

--- a/typescript/app/random/random.riot
+++ b/typescript/app/random/random.riot
@@ -12,7 +12,6 @@
   <logs logs={ state.logs } onclear={ clearLogs }></logs>
 
   <script type="ts">
-    import Logs from '../logs/logs.riot'
     import {RandomComponent} from './types'
 
     function Random(): RandomComponent {
@@ -35,10 +34,6 @@
           })
         }
       }
-    }
-
-    Random.components = {
-      Logs
     }
 
     export default Random

--- a/typescript/app/random/random.riot
+++ b/typescript/app/random/random.riot
@@ -12,7 +12,7 @@
   <logs logs={ state.logs } onclear={ clearLogs }></logs>
 
   <script type="ts">
-    import Logs from '../logs/logs.riot'
+    import Logs from '../logs.riot'
     import {RandomComponent} from './types'
 
     function Random(): RandomComponent {

--- a/typescript/app/random/random.riot
+++ b/typescript/app/random/random.riot
@@ -9,7 +9,10 @@
     { state.number }
   </h1>
 
+  <logs logs={ state.logs } onclear={ clearLogs }></logs>
+
   <script type="ts">
+    import Logs from '../logs/logs.riot'
     import {RandomComponent} from './types'
 
     function Random(): RandomComponent {
@@ -32,6 +35,10 @@
           })
         }
       }
+    }
+
+    Random.components = {
+      Logs
     }
 
     export default Random

--- a/typescript/app/random/random.riot
+++ b/typescript/app/random/random.riot
@@ -9,8 +9,6 @@
     { state.number }
   </h1>
 
-  <logs logs={ state.logs } onclear={ clearLogs }></logs>
-
   <script type="ts">
     import {RandomComponent} from './types'
 


### PR DESCRIPTION
To successfully run the typescript example i had to remove the log component, otherwise the example won't start.
I've seen that there is a logs tag defined under the webpack example, maybe it can be added here also if it's needed.