### PR TITLE
chore: tsconfig noImplicitThis

### DIFF
--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -6,7 +6,8 @@
     "sourceMap": true,
     "noUnusedLocals": false,
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noImplicitThis": true
   },
   "include": [
     "app"


### PR DESCRIPTION
To potentially avoid anyone being as confused as I was for weeks as to why object functions weren't receiving a lexical this -_-